### PR TITLE
fix: 🐛 use old git command to get current branch

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -33,6 +33,7 @@ export default class Configuration {
     };
     pathsToIncludes: string[];
   }[];
+  currentBranch: string;
 
   private getRootPackage(): PackageJSON {
     if (this.isAGitRepository) {
@@ -71,7 +72,7 @@ export default class Configuration {
     if (!this.isAGitRepository) {
       process.exit(1);
     }
-
+    this.currentBranch = execa.commandSync('git symbolic-ref -q --short HEAD').stdout;
     this.root = execa.commandSync('git rev-parse --show-toplevel').stdout;
     this.rootPackage = this.getRootPackage();
     this.isMonorepo = this.checkIsMonorepo();

--- a/src/tooling.ts
+++ b/src/tooling.ts
@@ -37,7 +37,7 @@ export default class Tooling extends Configuration {
   }
 
   public getChangesWithoutAffecteds(ref: string) {
-    const currentBrahnch = execa.commandSync('git branch --show-current').stdout;
+    const currentBrahnch = this.currentBranch;
     const changes = execa
       .commandSync(`git diff --name-only ${ref}..${currentBrahnch}`)
       .stdout.split('\n')
@@ -46,7 +46,7 @@ export default class Tooling extends Configuration {
   }
 
   public getChangesWithAffecteds(ref: string) {
-    const currentBrahnch = execa.commandSync('git branch --show-current').stdout;
+    const currentBrahnch = this.currentBranch;
     const changes = execa
       .commandSync(`git diff --name-only ${ref}..${currentBrahnch}`)
       .stdout.split('\n')


### PR DESCRIPTION
This fix is to prevent issues on CI env